### PR TITLE
Update metrics-api.mdx

### DIFF
--- a/docs/docs/metrics/metrics-api.mdx
+++ b/docs/docs/metrics/metrics-api.mdx
@@ -62,7 +62,7 @@ No parameters
 
   ```json
   {
-    "api_version": "v1.0.0"
+    "spec_version": "v1.0.0"
   }
   ```
 


### PR DESCRIPTION
Was this a typo? Or is `spec_version` the same as `api_version`?

Pretty confused about the different `versions`. For eg: What is eigen_version in https://eigen.nethermind.io/docs/metrics/metrics-prom-spec? The manifest file has a spec_version (https://eigen.nethermind.io/docs/metrics/metrics-api#get-eigennodespec-version) and node_version (https://eigen.nethermind.io/docs/metrics/metrics-api#get-eigennodeversion), but those seem to already be labels in the eigen_version metric. Unless the version label is a typo?